### PR TITLE
Fixes to Hold Call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+public/appConfig.js

--- a/src/functions/call-outbound-join.js
+++ b/src/functions/call-outbound-join.js
@@ -98,9 +98,9 @@ exports.handler = function(context, event, callback) {
                 return;
             } else {
 
-                console.log(`call triggered, callSid ${participant.callSid}`);
+                console.log(`call triggered, callSid ${result.callSid}`);
 
-                attributes.conference.participants.customer = participant.callSid;
+                attributes.conference.participants.customer = result.callSid;
 
                 return updateTaskAttributes(client, context, taskSid, attributes);
 


### PR DESCRIPTION
This change will allow you to hold calls again. The issue is that participant is undefined at this point in execution. I believe the actual required data is stored in the variable result - i am able to hold calls with this change.